### PR TITLE
Redirect to next

### DIFF
--- a/octopus/modules/account/account.py
+++ b/octopus/modules/account/account.py
@@ -43,6 +43,10 @@ def login():
     # current_info = {'next': request.args.get('next', '')}
     fc = AccountFactory.get_login_formcontext(request.form)
 
+    next = request.args.get('next')
+    if next:
+        fc.form.next.data = next
+
     if request.method == 'POST':
         if fc.validate():
             password = fc.form.password.data


### PR DESCRIPTION
Associated with [#131990631] Change HTTP403 to redirect - changes where made in order to redirect to "next" params after successfull login
